### PR TITLE
Add Vitest setup and hook tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -29,6 +30,10 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.2.0",
+    "jsdom": "^22.1.0"
   }
 }

--- a/src/__tests__/useAudioPlayer.test.ts
+++ b/src/__tests__/useAudioPlayer.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAudioPlayer } from '../hooks/useAudioPlayer';
+import { Track } from '../types';
+
+class MockAudio {
+  public src = '';
+  public preload = '';
+  public currentTime = 0;
+  public duration = 0;
+  public volume = 1;
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+  load = vi.fn();
+  play = vi.fn().mockResolvedValue(undefined);
+  pause = vi.fn();
+}
+
+describe('useAudioPlayer', () => {
+  const track: Track = {
+    id: '1',
+    title: 'Test',
+    artist: 'Artist',
+    duration: 10,
+    url: 'test.mp3',
+  };
+
+  beforeAll(() => {
+    vi.stubGlobal('Audio', MockAudio);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads a track into state', () => {
+    const { result } = renderHook(() => useAudioPlayer());
+    act(() => {
+      result.current.loadTrack(track);
+    });
+    expect(result.current.playerState.currentTrack).toEqual(track);
+    expect(result.current.playerState.isPlaying).toBe(false);
+  });
+
+  it('plays and pauses the track', async () => {
+    const { result } = renderHook(() => useAudioPlayer());
+    act(() => {
+      result.current.loadTrack(track);
+    });
+    await act(() => result.current.play());
+    expect(result.current.playerState.isPlaying).toBe(true);
+    act(() => {
+      result.current.pause();
+    });
+    expect(result.current.playerState.isPlaying).toBe(false);
+  });
+});

--- a/src/__tests__/useLocalStorage.test.ts
+++ b/src/__tests__/useLocalStorage.test.ts
@@ -1,0 +1,24 @@
+import { renderHook, act } from '@testing-library/react';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('initializes with value from localStorage', () => {
+    window.localStorage.setItem('foo', JSON.stringify('bar'));
+    const { result } = renderHook(() => useLocalStorage('foo', 'baz'));
+    expect(result.current[0]).toBe('bar');
+  });
+
+  it('updates localStorage when value changes', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'start'));
+    act(() => {
+      const [, setValue] = result.current;
+      setValue('updated');
+    });
+    expect(window.localStorage.getItem('key')).toBe(JSON.stringify('updated'));
+    expect(result.current[0]).toBe('updated');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary
- set up Vitest for unit testing
- add `npm test` script
- configure jsdom test environment
- add tests for `useLocalStorage` and `useAudioPlayer` hooks

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e9fef15883248704da2c51785560