### PR TITLE
Enable playlist editing and track management

### DIFF
--- a/src/components/content/TrackList.tsx
+++ b/src/components/content/TrackList.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { Play, Pause, Heart, MoreHorizontal } from 'lucide-react';
+import {
+  Play,
+  Pause,
+  Heart,
+  MoreHorizontal,
+  Pencil,
+  Trash,
+  ArrowUp,
+  ArrowDown,
+} from 'lucide-react';
 import { Track } from '../../types';
 import { formatTime } from '../../utils/format';
 import { Button } from '../common/Button';
@@ -13,6 +22,10 @@ interface TrackListProps {
   onToggleFavorite: (trackId: string) => void;
   showAlbum?: boolean;
   showArtwork?: boolean;
+  onRenameTrack?: (trackId: string) => void;
+  onRemoveTrack?: (trackId: string) => void;
+  onMoveTrackUp?: (index: number) => void;
+  onMoveTrackDown?: (index: number) => void;
 }
 
 export const TrackList: React.FC<TrackListProps> = ({
@@ -23,6 +36,10 @@ export const TrackList: React.FC<TrackListProps> = ({
   onToggleFavorite,
   showAlbum = true,
   showArtwork = true,
+  onRenameTrack,
+  onRemoveTrack,
+  onMoveTrackUp,
+  onMoveTrackDown,
 }) => {
   return (
     <div className="space-y-1">
@@ -122,11 +139,11 @@ export const TrackList: React.FC<TrackListProps> = ({
                 }`}
                 ariaLabel={track.isFavorite ? 'Retirer des favoris' : 'Ajouter aux favoris'}
               />
-              
+
               <span className="text-sm text-gray-500 dark:text-gray-400 w-12 text-right">
                 {formatTime(track.duration)}
               </span>
-              
+
               <Button
                 variant="ghost"
                 size="sm"
@@ -135,6 +152,62 @@ export const TrackList: React.FC<TrackListProps> = ({
                 onClick={(e) => e.stopPropagation()}
                 ariaLabel="Plus d'options"
               />
+
+              {onMoveTrackUp && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={ArrowUp}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onMoveTrackUp(index);
+                  }}
+                  ariaLabel="Monter le titre"
+                />
+              )}
+
+              {onMoveTrackDown && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={ArrowDown}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onMoveTrackDown(index);
+                  }}
+                  ariaLabel="Descendre le titre"
+                />
+              )}
+
+              {onRenameTrack && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={Pencil}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRenameTrack(track.id);
+                  }}
+                  ariaLabel="Renommer le titre"
+                />
+              )}
+
+              {onRemoveTrack && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={Trash}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemoveTrack(track.id);
+                  }}
+                  ariaLabel="Supprimer le titre"
+                />
+              )}
             </div>
           </motion.div>
         );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -5,10 +5,12 @@ import {
   Search, 
   Library, 
   Heart, 
-  Plus, 
+  Plus,
   Music,
   TrendingUp,
-  Clock
+  Clock,
+  Pencil,
+  Trash
 } from 'lucide-react';
 import { Button } from '../common/Button';
 import { Playlist } from '../../types';
@@ -18,6 +20,8 @@ interface SidebarProps {
   activeSection: string;
   onSectionChange: (section: string) => void;
   onCreatePlaylist: () => void;
+  onRenamePlaylist: (id: string) => void;
+  onDeletePlaylist: (id: string) => void;
 }
 
 export const Sidebar: React.FC<SidebarProps> = ({
@@ -25,6 +29,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
   activeSection,
   onSectionChange,
   onCreatePlaylist,
+  onRenamePlaylist,
+  onDeletePlaylist,
 }) => {
   const navItems = [
     { id: 'home', label: 'Accueil', icon: Home },
@@ -86,24 +92,44 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
         <div className="space-y-2">
           {playlists.map((playlist) => (
-            <motion.button
+            <motion.div
               key={playlist.id}
-              onClick={() => onSectionChange(`playlist-${playlist.id}`)}
-              className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              className="w-full flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors group"
               whileHover={{ scale: 1.02 }}
             >
-              <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-primary-500 to-accent-500 flex items-center justify-center flex-shrink-0">
-                <Music className="w-5 h-5 text-white" />
+              <button
+                onClick={() => onSectionChange(`playlist-${playlist.id}`)}
+                className="flex items-center space-x-3 flex-1 text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-primary-500 to-accent-500 flex items-center justify-center flex-shrink-0">
+                  <Music className="w-5 h-5 text-white" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-gray-900 dark:text-white truncate">
+                    {playlist.name}
+                  </p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    {playlist.tracks.length} titre{playlist.tracks.length > 1 ? 's' : ''}
+                  </p>
+                </div>
+              </button>
+              <div className="flex-shrink-0 flex space-x-1 opacity-0 group-hover:opacity-100">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={Pencil}
+                  ariaLabel="Renommer la playlist"
+                  onClick={() => onRenamePlaylist(playlist.id)}
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={Trash}
+                  ariaLabel="Supprimer la playlist"
+                  onClick={() => onDeletePlaylist(playlist.id)}
+                />
               </div>
-              <div className="flex-1 min-w-0">
-                <p className="font-medium text-gray-900 dark:text-white truncate">
-                  {playlist.name}
-                </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  {playlist.tracks.length} titre{playlist.tracks.length > 1 ? 's' : ''}
-                </p>
-              </div>
-            </motion.button>
+            </motion.div>
           ))}
 
           {playlists.length === 0 && (


### PR DESCRIPTION
## Summary
- allow editing and deleting playlists in the sidebar
- expose playlist and track management handlers in `App.tsx`
- show edit/delete controls on playlist pages
- support renaming, reordering and removing tracks in `TrackList`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6843ea0b021483248c40705358e055f8