### PR TITLE
Add drag and drop reordering for playlist tracks

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "framer-motion": "^10.16.16"
+    "framer-motion": "^10.16.16",
+    "react-beautiful-dnd": "^13.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -285,6 +285,7 @@ function App() {
                     }}
                     onMoveTrackUp={(index) => handleReorderTracks(playlist.id, index, Math.max(0, index - 1))}
                     onMoveTrackDown={(index) => handleReorderTracks(playlist.id, index, Math.min(playlist.tracks.length - 1, index + 1))}
+                    onReorder={(from, to) => handleReorderTracks(playlist.id, from, to)}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add `react-beautiful-dnd` as dependency
- enable drag & drop in `TrackList` using `DragDropContext`
- hook track reorder callback from playlists

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f2a868b483248bb344b0f8d2624c