### PR TITLE
Fix track removal cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,6 +140,12 @@ function App() {
   };
 
   const handleRemoveTrack = (playlistId: string, trackId: string) => {
+    const playlist = playlists.find(p => p.id === playlistId);
+    const track = playlist?.tracks.find(t => t.id === trackId);
+    if (track && track.url.startsWith('blob:')) {
+      URL.revokeObjectURL(track.url);
+    }
+
     setPlaylists(prev =>
       prev.map(p =>
         p.id === playlistId
@@ -151,6 +157,8 @@ function App() {
           : p
       )
     );
+
+    setTracks(prev => prev.filter(t => t.id !== trackId));
   };
 
   const handleReorderTracks = (


### PR DESCRIPTION
## Summary
- release object URL when removing a track
- keep playlists and track state up to date

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f2c5de0c83249488d65d052c7ede