### PR TITLE
Fix playlist interface crash

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,5 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
## Summary
- remove React.StrictMode wrapper to fix DragDropContext crash

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f59176288324ae51aed60943f28c