### PR TITLE
Add WAV support

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -83,7 +83,7 @@ export const Header: React.FC<HeaderProps> = ({
             <input
               id="file-upload"
               type="file"
-              accept=".mp3,.flac,.ogg"
+              accept=".mp3,.flac,.ogg,.wav"
               multiple
               className="hidden"
               onChange={(e) => {


### PR DESCRIPTION
## Summary
- allow uploading `.wav` files via the header input

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f87044d88324ac1a5c231d09eb54