### PR TITLE
Add playback queue UI

### DIFF
--- a/src/__tests__/useAudioPlayer.test.ts
+++ b/src/__tests__/useAudioPlayer.test.ts
@@ -53,4 +53,15 @@ describe('useAudioPlayer', () => {
     });
     expect(result.current.playerState.isPlaying).toBe(false);
   });
+
+  it('plays track at index from queue', async () => {
+    const { result } = renderHook(() => useAudioPlayer());
+    act(() => {
+      result.current.setQueue([track], 0);
+    });
+    await act(() => result.current.playTrackAtIndex(0));
+    expect(result.current.playerState.currentIndex).toBe(0);
+    expect(result.current.playerState.currentTrack).toEqual(track);
+    expect(result.current.playerState.isPlaying).toBe(true);
+  });
 });

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronUp, ChevronDown, Play, Pause } from 'lucide-react';
 import { PlayerControls } from './PlayerControls';
 import { NowPlaying } from './NowPlaying';
+import { Queue } from './Queue';
 import { Button } from '../common/Button';
 import { useAudioPlayer } from '../../hooks/useAudioPlayer';
 
@@ -22,7 +23,10 @@ export const Player: React.FC<PlayerProps> = ({ isExpanded, onToggleExpanded }) 
     toggleMute,
     toggleShuffle,
     toggleRepeat,
+    playTrackAtIndex,
   } = useAudioPlayer();
+
+  const [showQueue, setShowQueue] = useState(false);
 
   const handleToggleFavorite = () => {
     // This would update the track's favorite status
@@ -93,7 +97,26 @@ export const Player: React.FC<PlayerProps> = ({ isExpanded, onToggleExpanded }) 
                 onToggleShuffle={toggleShuffle}
                 onToggleRepeat={toggleRepeat}
                 onToggleFavorite={handleToggleFavorite}
+                isQueueVisible={showQueue}
+                onToggleQueue={() => setShowQueue(!showQueue)}
               />
+
+              <AnimatePresence>
+                {showQueue && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: 10 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    <Queue
+                      tracks={playerState.queue}
+                      currentIndex={playerState.currentIndex}
+                      onSelect={playTrackAtIndex}
+                    />
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </div>
           </motion.div>
         )}

--- a/src/components/player/PlayerControls.tsx
+++ b/src/components/player/PlayerControls.tsx
@@ -6,10 +6,11 @@ import {
   SkipBack, 
   SkipForward, 
   Shuffle, 
-  Repeat, 
-  Volume2, 
+  Repeat,
+  Volume2,
   VolumeX,
-  Heart 
+  Heart,
+  ListMusic
 } from 'lucide-react';
 import { Button } from '../common/Button';
 import { formatTime } from '../../utils/format';
@@ -32,6 +33,8 @@ interface PlayerControlsProps {
   onToggleShuffle: () => void;
   onToggleRepeat: () => void;
   onToggleFavorite?: () => void;
+  isQueueVisible?: boolean;
+  onToggleQueue?: () => void;
 }
 
 export const PlayerControls: React.FC<PlayerControlsProps> = ({
@@ -52,6 +55,8 @@ export const PlayerControls: React.FC<PlayerControlsProps> = ({
   onToggleShuffle,
   onToggleRepeat,
   onToggleFavorite,
+  isQueueVisible = false,
+  onToggleQueue,
 }) => {
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
@@ -152,6 +157,18 @@ export const PlayerControls: React.FC<PlayerControlsProps> = ({
             onClick={onToggleFavorite}
             className={isFavorite ? 'text-red-500' : 'text-gray-400'}
             ariaLabel={isFavorite ? 'Retirer des favoris' : 'Ajouter aux favoris'}
+          />
+        )}
+
+        {/* Queue Toggle */}
+        {onToggleQueue && (
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={ListMusic}
+            onClick={onToggleQueue}
+            className={isQueueVisible ? 'text-primary-600' : 'text-gray-400'}
+            ariaLabel="File de lecture"
           />
         )}
 

--- a/src/components/player/Queue.tsx
+++ b/src/components/player/Queue.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Track } from '../../types';
+import { formatTime } from '../../utils/format';
+
+interface QueueProps {
+  tracks: Track[];
+  currentIndex: number;
+  onSelect: (index: number) => void;
+}
+
+export const Queue: React.FC<QueueProps> = ({ tracks, currentIndex, onSelect }) => {
+  if (tracks.length === 0) {
+    return (
+      <div className="text-sm text-gray-500 dark:text-gray-400 mt-4">
+        File de lecture vide
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-h-60 overflow-y-auto mt-4 space-y-1">
+      {tracks.map((track, index) => (
+        <button
+          key={track.id}
+          onClick={() => onSelect(index)}
+          className={`w-full flex justify-between px-3 py-1 rounded-md text-left focus:outline-none ${index === currentIndex ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+        >
+          <span className="truncate">{track.title}</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {formatTime(track.duration)}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -200,13 +200,26 @@ export const useAudioPlayer = () => {
   const toggleRepeat = useCallback(() => {
     setPlayerState(prev => ({
       ...prev,
-      repeatMode: prev.repeatMode === 'none' 
-        ? 'all' 
-        : prev.repeatMode === 'all' 
-        ? 'one' 
+      repeatMode: prev.repeatMode === 'none'
+        ? 'all'
+        : prev.repeatMode === 'all'
+        ? 'one'
         : 'none'
     }));
   }, []);
+
+  const playTrackAtIndex = useCallback(
+    async (index: number) => {
+      const track = playerState.queue[index];
+      if (!track) return;
+      setPlayerState(prev => ({ ...prev, currentIndex: index }));
+      loadTrack(track);
+      if (playerState.isPlaying) {
+        await play();
+      }
+    },
+    [playerState.queue, playerState.isPlaying, loadTrack, play]
+  );
 
   return {
     playerState,
@@ -222,5 +235,6 @@ export const useAudioPlayer = () => {
     toggleShuffle,
     toggleRepeat,
     loadTrack,
+    playTrackAtIndex,
   };
 };


### PR DESCRIPTION
## Summary
- implement queue component for player
- expand PlayerControls to toggle queue view
- integrate queue selection in Player using new hook helper
- support playTrackAtIndex in useAudioPlayer
- update tests for new hook method

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684404fb2cfc8324a5af8422b9883d9a