### PR TITLE
Add Settings modal for account and preferences

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Player } from './components/player/Player';
 import { AuthModal } from './components/auth/AuthModal';
 import { HomeContent } from './components/content/HomeContent';
 import { TrackList } from './components/content/TrackList';
+import { SettingsModal } from './components/settings/SettingsModal';
 import { Pencil, Trash } from 'lucide-react';
 import { useLocalStorage } from './hooks/useLocalStorage';
 import { useAudioPlayer } from './hooks/useAudioPlayer';
@@ -16,6 +17,7 @@ import { User, Track, Playlist } from './types';
 function App() {
   const [user, setUser] = useLocalStorage<User | null>('sworn-user', null);
   const [showAuthModal, setShowAuthModal] = useState(false);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
   const [activeSection, setActiveSection] = useState('home');
   const [isPlayerExpanded, setIsPlayerExpanded] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -121,6 +123,10 @@ function App() {
   const handleLogout = () => {
     setUser(null);
     localStorage.removeItem('sworn-user');
+  };
+
+  const handleUserUpdate = (updated: User) => {
+    setUser(updated);
   };
 
   const handleTrackSelect = (track: Track, trackList: Track[]) => {
@@ -396,6 +402,7 @@ function App() {
         onLogout={handleLogout}
         onFilesSelected={handleFilesSelected}
         onSearchChange={setSearchQuery}
+        onSettingsClick={() => setShowSettingsModal(true)}
       />
 
       <div className="flex flex-1 overflow-hidden">
@@ -436,6 +443,13 @@ function App() {
           />
         )}
       </AnimatePresence>
+
+      <SettingsModal
+        isOpen={showSettingsModal}
+        onClose={() => setShowSettingsModal(false)}
+        user={user}
+        onUserUpdate={handleUserUpdate}
+      />
 
       <AuthModal
         isOpen={showAuthModal}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,6 +21,7 @@ interface HeaderProps {
   onLogout: () => void;
   onFilesSelected: (files: FileList) => void;
   onSearchChange: (query: string) => void;
+  onSettingsClick: () => void;
 }
 
 export const Header: React.FC<HeaderProps> = ({
@@ -29,6 +30,7 @@ export const Header: React.FC<HeaderProps> = ({
   onLogout,
   onFilesSelected,
   onSearchChange,
+  onSettingsClick,
 }) => {
   const { theme, changeTheme } = useTheme();
   const [showUserMenu, setShowUserMenu] = React.useState(false);
@@ -133,7 +135,7 @@ export const Header: React.FC<HeaderProps> = ({
                       <User className="w-4 h-4" />
                       <span>Profil</span>
                     </button>
-                    <button className="flex items-center space-x-2 w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
+                    <button onClick={() => { setShowUserMenu(false); onSettingsClick(); }} className="flex items-center space-x-2 w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
                       <Settings className="w-4 h-4" />
                       <span>Paramètres</span>
                     </button>

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import { Modal } from '../common/Modal';
+import { Button } from '../common/Button';
+import { User } from '../../types';
+import { useTheme, Theme } from '../../hooks/useTheme';
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  user: User | null;
+  onUserUpdate: (user: User) => void;
+}
+
+export const SettingsModal: React.FC<SettingsModalProps> = ({
+  isOpen,
+  onClose,
+  user,
+  onUserUpdate,
+}) => {
+  const { theme, changeTheme } = useTheme();
+  const [localUser, setLocalUser] = useState<User | null>(user);
+
+  useEffect(() => {
+    setLocalUser(user);
+  }, [user]);
+
+  const handleSave = () => {
+    if (localUser) {
+      onUserUpdate(localUser);
+    }
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Param\xE8tres" size="lg">
+      <div className="space-y-6">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Gestion du compte</h3>
+          {localUser ? (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Nom
+                </label>
+                <input
+                  type="text"
+                  value={localUser.name}
+                  onChange={(e) => setLocalUser({ ...localUser, name: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-800 dark:text-white"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Email
+                </label>
+                <input
+                  type="email"
+                  value={localUser.email}
+                  onChange={(e) => setLocalUser({ ...localUser, email: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-800 dark:text-white"
+                />
+              </div>
+              <Button onClick={handleSave} variant="primary" size="md" className="mt-2">
+                Enregistrer
+              </Button>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-600 dark:text-gray-400">Aucun utilisateur connect\xE9.</p>
+          )}
+        </div>
+
+        <hr className="border-gray-200 dark:border-gray-700" />
+
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Pr\xE9f\xE9rences</h3>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Th\xE8me
+            </label>
+            <select
+              value={theme}
+              onChange={(e) => changeTheme(e.target.value as Theme)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-800 dark:text-white"
+            >
+              <option value="light">Clair</option>
+              <option value="dark">Sombre</option>
+              <option value="system">Syst\xE8me</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+


### PR DESCRIPTION
## Summary
- implement `SettingsModal` component for account and theme preferences
- add menu action in `Header` to open settings
- integrate settings modal in `App` state

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684407910e408324aac8029b5ebabab6