### PR TITLE
Add metadata extraction for local files

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { Pencil, Trash } from 'lucide-react';
 import { useLocalStorage } from './hooks/useLocalStorage';
 import { useAudioPlayer } from './hooks/useAudioPlayer';
 import { User, Track, Playlist } from './types';
+import { extractMetadata } from './utils/metadata';
 
 
 function App() {
@@ -93,12 +94,15 @@ function App() {
   const handleFilesSelected = async (files: FileList) => {
     const newTracks: Track[] = [];
     for (const file of Array.from(files)) {
-      const duration = await getAudioDuration(file);
+      const [duration, meta] = await Promise.all([
+        getAudioDuration(file),
+        extractMetadata(file),
+      ]);
       newTracks.push({
         id: `local-${Date.now()}-${Math.random()}`,
-        title: file.name.replace(/\.[^/.]+$/, ''),
-        artist: 'Local',
-        album: 'Local Files',
+        title: meta.title || file.name.replace(/\.[^/.]+$/, ''),
+        artist: meta.artist || 'Local',
+        album: meta.album || 'Local Files',
         duration,
         url: URL.createObjectURL(file),
         isFavorite: false,

--- a/src/__tests__/metadata.test.ts
+++ b/src/__tests__/metadata.test.ts
@@ -1,0 +1,35 @@
+import { extractMetadata } from '../utils/metadata';
+
+describe('extractMetadata', () => {
+  const createId3v1File = (
+    title: string,
+    artist: string,
+    album: string
+  ): File => {
+    const tag = new Uint8Array(128);
+    tag.set([0x54, 0x41, 0x47], 0); // "TAG"
+    const fill = (text: string, start: number) => {
+      for (let i = 0; i < 30; i++) {
+        tag[start + i] = i < text.length ? text.charCodeAt(i) : 0;
+      }
+    };
+    fill(title, 3);
+    fill(artist, 33);
+    fill(album, 63);
+    // prepend some dummy audio data
+    const dummy = new Uint8Array([1, 2, 3, 4]);
+    return new File([dummy, tag], 'track.mp3');
+  };
+
+  it('reads ID3v1 metadata', async () => {
+    const file = createId3v1File('Title', 'Artist', 'Album');
+    const meta = await extractMetadata(file);
+    expect(meta).toEqual({ title: 'Title', artist: 'Artist', album: 'Album' });
+  });
+
+  it('returns empty object when no metadata', async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], 'empty.mp3');
+    const meta = await extractMetadata(file);
+    expect(meta).toEqual({});
+  });
+});

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,0 +1,49 @@
+export interface AudioMetadata {
+  title?: string;
+  artist?: string;
+  album?: string;
+}
+
+/**
+ * Extract basic ID3v1 metadata from an audio file.
+ * Returns empty fields if no metadata is found or an error occurs.
+ */
+export const extractMetadata = (file: File): Promise<AudioMetadata> => {
+  return new Promise(resolve => {
+    const slice = file.slice(Math.max(0, file.size - 128), file.size);
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const buffer = reader.result as ArrayBuffer;
+      const data = new Uint8Array(buffer);
+      if (data.length >= 128) {
+        const decoder = new TextDecoder('iso-8859-1');
+        if (
+          decoder
+            .decode(data.subarray(0, 3))
+            .replace(/\0+$/, '')
+            .toUpperCase() === 'TAG'
+        ) {
+          const title = decoder
+            .decode(data.subarray(3, 33))
+            .replace(/\0+$/, '')
+            .trim();
+          const artist = decoder
+            .decode(data.subarray(33, 63))
+            .replace(/\0+$/, '')
+            .trim();
+          const album = decoder
+            .decode(data.subarray(63, 93))
+            .replace(/\0+$/, '')
+            .trim();
+          resolve({ title, artist, album });
+          return;
+        }
+      }
+      resolve({});
+    };
+
+    reader.onerror = () => resolve({});
+    reader.readAsArrayBuffer(slice);
+  });
+};


### PR DESCRIPTION
## Summary
- parse ID3v1 tags from audio files with new `extractMetadata` util
- use the metadata when adding audio tracks
- cover metadata extraction with tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440e7b27308324a6104539635b2900