### PR TITLE
Add additional content pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,9 @@ import { HomeContent } from './components/content/HomeContent';
 import { TrackList } from './components/content/TrackList';
 import { PlaylistsPage } from './components/content/PlaylistsPage';
 import { PlaylistPage } from './components/content/PlaylistPage';
+import { SearchPage } from './components/content/SearchPage';
+import { TrendingPage } from './components/content/TrendingPage';
+import { RecentPage } from './components/content/RecentPage';
 import { SettingsModal } from './components/settings/SettingsModal';
 import { Pencil, Trash } from 'lucide-react';
 import { useLocalStorage } from './hooks/useLocalStorage';
@@ -26,6 +29,7 @@ function App() {
   const [playlists, setPlaylists] = useLocalStorage<Playlist[]>('sworn-playlists', []);
   const [tracks, setTracks] = useLocalStorage<Track[]>('sworn-tracks', []);
   const [favorites, setFavorites] = useLocalStorage<string[]>('sworn-favorites', []);
+  const [recentHistory, setRecentHistory] = useLocalStorage<Track[]>('sworn-recent', []);
 
   const { playerState, setQueue, loadTrack, play } = useAudioPlayer();
 
@@ -138,6 +142,10 @@ function App() {
     const trackIndex = trackList.findIndex(t => t.id === track.id);
     setQueue(trackList, trackIndex);
     setTimeout(() => play(), 100);
+    setRecentHistory(prev => {
+      const filtered = prev.filter(t => t.id !== track.id);
+      return [track, ...filtered].slice(0, 20);
+    });
   };
 
   const handleToggleFavorite = (trackId: string) => {
@@ -272,6 +280,42 @@ function App() {
             onTrackSelect={handleTrackSelect}
             onToggleFavorite={handleToggleFavorite}
             onPlaylistSelect={handlePlaylistSelect}
+          />
+        );
+
+      case 'search':
+        const searchTracks = filterTracks(tracks);
+        return (
+          <SearchPage
+            query={searchQuery}
+            tracks={searchTracks}
+            currentTrack={playerState.currentTrack}
+            isPlaying={playerState.isPlaying}
+            onTrackSelect={(track, index) => handleTrackSelect(track, searchTracks)}
+            onToggleFavorite={handleToggleFavorite}
+          />
+        );
+
+      case 'recent':
+        return (
+          <RecentPage
+            tracks={filterTracks(recentHistory)}
+            currentTrack={playerState.currentTrack}
+            isPlaying={playerState.isPlaying}
+            onTrackSelect={(track, index) => handleTrackSelect(track, recentHistory)}
+            onToggleFavorite={handleToggleFavorite}
+          />
+        );
+
+      case 'trending':
+        const trendTracks = filterTracks(tracks);
+        return (
+          <TrendingPage
+            tracks={trendTracks}
+            currentTrack={playerState.currentTrack}
+            isPlaying={playerState.isPlaying}
+            onTrackSelect={(track, index) => handleTrackSelect(track, trendTracks)}
+            onToggleFavorite={handleToggleFavorite}
           />
         );
       

--- a/src/components/content/RecentPage.tsx
+++ b/src/components/content/RecentPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Track } from '../../types';
+import { TrackList } from './TrackList';
+
+interface RecentPageProps {
+  tracks: Track[];
+  currentTrack: Track | null;
+  isPlaying: boolean;
+  onTrackSelect: (track: Track, index: number) => void;
+  onToggleFavorite: (trackId: string) => void;
+}
+
+export const RecentPage: React.FC<RecentPageProps> = ({
+  tracks,
+  currentTrack,
+  isPlaying,
+  onTrackSelect,
+  onToggleFavorite,
+}) => {
+  return (
+    <div className="space-y-6">
+      <div className="bg-gradient-to-r from-blue-500 to-indigo-500 rounded-2xl p-8 text-white">
+        <h1 className="text-3xl font-bold mb-2">Récemment joués</h1>
+        <p className="text-blue-100">
+          {tracks.length} titre{tracks.length > 1 ? 's' : ''}
+        </p>
+      </div>
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6">
+        <TrackList
+          tracks={tracks}
+          currentTrack={currentTrack}
+          isPlaying={isPlaying}
+          onTrackSelect={(track, index) => onTrackSelect(track, index)}
+          onToggleFavorite={onToggleFavorite}
+          showArtwork={true}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/content/SearchPage.tsx
+++ b/src/components/content/SearchPage.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Track } from '../../types';
+import { TrackList } from './TrackList';
+
+interface SearchPageProps {
+  query: string;
+  tracks: Track[];
+  currentTrack: Track | null;
+  isPlaying: boolean;
+  onTrackSelect: (track: Track, index: number) => void;
+  onToggleFavorite: (trackId: string) => void;
+}
+
+export const SearchPage: React.FC<SearchPageProps> = ({
+  query,
+  tracks,
+  currentTrack,
+  isPlaying,
+  onTrackSelect,
+  onToggleFavorite,
+}) => {
+  return (
+    <div className="space-y-6">
+      <div className="bg-gradient-to-r from-green-500 to-emerald-500 rounded-2xl p-8 text-white">
+        <h1 className="text-3xl font-bold mb-2">Recherche</h1>
+        <p className="text-green-100">
+          {tracks.length} titre{tracks.length > 1 ? 's' : ''} pour "{query}"
+        </p>
+      </div>
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6">
+        <TrackList
+          tracks={tracks}
+          currentTrack={currentTrack}
+          isPlaying={isPlaying}
+          onTrackSelect={(track, index) => onTrackSelect(track, index)}
+          onToggleFavorite={onToggleFavorite}
+          showArtwork={true}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/content/TrendingPage.tsx
+++ b/src/components/content/TrendingPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Track } from '../../types';
+import { TrackList } from './TrackList';
+
+interface TrendingPageProps {
+  tracks: Track[];
+  currentTrack: Track | null;
+  isPlaying: boolean;
+  onTrackSelect: (track: Track, index: number) => void;
+  onToggleFavorite: (trackId: string) => void;
+}
+
+export const TrendingPage: React.FC<TrendingPageProps> = ({
+  tracks,
+  currentTrack,
+  isPlaying,
+  onTrackSelect,
+  onToggleFavorite,
+}) => {
+  return (
+    <div className="space-y-6">
+      <div className="bg-gradient-to-r from-orange-500 to-pink-500 rounded-2xl p-8 text-white">
+        <h1 className="text-3xl font-bold mb-2">Tendances</h1>
+        <p className="text-orange-100">
+          {tracks.length} titre{tracks.length > 1 ? 's' : ''}
+        </p>
+      </div>
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6">
+        <TrackList
+          tracks={tracks}
+          currentTrack={currentTrack}
+          isPlaying={isPlaying}
+          onTrackSelect={(track, index) => onTrackSelect(track, index)}
+          onToggleFavorite={onToggleFavorite}
+          showArtwork={true}
+        />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add SearchPage, TrendingPage, and RecentPage components
- track recently played songs in local storage
- render new pages based on sidebar selection

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684416b87ea083249ed0b2f161ee3f7b