### PR TITLE
Add Recently Added tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { PlaylistPage } from './components/content/PlaylistPage';
 import { SearchPage } from './components/content/SearchPage';
 import { TrendingPage } from './components/content/TrendingPage';
 import { RecentPage } from './components/content/RecentPage';
+import { AddedPage } from './components/content/AddedPage';
 import { SettingsModal } from './components/settings/SettingsModal';
 import { Pencil, Trash } from 'lucide-react';
 import { useLocalStorage } from './hooks/useLocalStorage';
@@ -306,6 +307,18 @@ function App() {
             currentTrack={playerState.currentTrack}
             isPlaying={playerState.isPlaying}
             onTrackSelect={(track, index) => handleTrackSelect(track, recentHistory)}
+            onToggleFavorite={handleToggleFavorite}
+          />
+        );
+
+      case 'added':
+        const addedTracks = filterTracks([...tracks]).reverse();
+        return (
+          <AddedPage
+            tracks={addedTracks}
+            currentTrack={playerState.currentTrack}
+            isPlaying={playerState.isPlaying}
+            onTrackSelect={(track, index) => handleTrackSelect(track, addedTracks)}
             onToggleFavorite={handleToggleFavorite}
           />
         );

--- a/src/components/content/AddedPage.tsx
+++ b/src/components/content/AddedPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Track } from '../../types';
+import { TrackList } from './TrackList';
+
+interface AddedPageProps {
+  tracks: Track[];
+  currentTrack: Track | null;
+  isPlaying: boolean;
+  onTrackSelect: (track: Track, index: number) => void;
+  onToggleFavorite: (trackId: string) => void;
+}
+
+export const AddedPage: React.FC<AddedPageProps> = ({
+  tracks,
+  currentTrack,
+  isPlaying,
+  onTrackSelect,
+  onToggleFavorite,
+}) => {
+  return (
+    <div className="space-y-6">
+      <div className="bg-gradient-to-r from-teal-500 to-cyan-500 rounded-2xl p-8 text-white">
+        <h1 className="text-3xl font-bold mb-2">Ajoutés récemment</h1>
+        <p className="text-teal-100">
+          {tracks.length} titre{tracks.length > 1 ? 's' : ''}
+        </p>
+      </div>
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6">
+        <TrackList
+          tracks={tracks}
+          currentTrack={currentTrack}
+          isPlaying={isPlaying}
+          onTrackSelect={(track, index) => onTrackSelect(track, index)}
+          onToggleFavorite={onToggleFavorite}
+          showArtwork={true}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Music,
   TrendingUp,
   Clock,
+  PlusCircle,
   Pencil,
   Trash
 } from 'lucide-react';
@@ -40,6 +41,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     { id: 'favorites', label: 'Favoris', icon: Heart },
     { id: 'trending', label: 'Tendances', icon: TrendingUp },
     { id: 'recent', label: 'Récemment joués', icon: Clock },
+    { id: 'added', label: 'Ajoutés récemment', icon: PlusCircle },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- add `AddedPage` component to display tracks recently imported
- show the new "Ajoutés récemment" section in the sidebar
- render recently added tracks in App

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442b69ec34832496b1bb10e206a052