### PR TITLE
Fix audio file load failures

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,10 +91,20 @@ function App() {
       const audio = document.createElement('audio');
       audio.preload = 'metadata';
       audio.src = URL.createObjectURL(file);
+
+      const cleanup = () => {
+        URL.revokeObjectURL(audio.src);
+      };
+
       audio.onloadedmetadata = () => {
         const duration = isNaN(audio.duration) ? 0 : audio.duration;
-        URL.revokeObjectURL(audio.src);
+        cleanup();
         resolve(duration);
+      };
+
+      audio.onerror = () => {
+        cleanup();
+        resolve(0);
       };
     });
   };


### PR DESCRIPTION
## Summary
- handle `onerror` when loading audio files to ensure promise resolves

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68442f2d80f88324b51bf25601105ce5